### PR TITLE
docs: add Rust doc comment for installed_snaps function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,19 @@ impl<C> SnapdClient<C>
 where
     C: Client,
 {
+    /// Fetches a list of installed snaps from the snapd daemon.
+    ///
+    /// # Arguments
+    ///
+    /// * `filter` - An optional filter to apply to the list of snaps,
+    ///   such as returning only enabled snaps. If `None`, it defaults to a
+    ///   standard selection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Error` if the communication with the snapd socket fails or
+    /// if the response cannot be parsed.
+    
     pub async fn installed_snaps(&self, filter: Option<SnapsFilter>) -> Result<Vec<Snap>> {
         let mut uri = "snaps".to_owned();
         if let Some(filter) = filter {


### PR DESCRIPTION
Summary

This pull request adds a comprehensive Rustdoc comment to the public `installed_snaps` function.

